### PR TITLE
Remove get_post() usage for EDD 3.0 compat #10

### DIFF
--- a/edd-downloads-as-services.php
+++ b/edd-downloads-as-services.php
@@ -204,10 +204,8 @@ if ( ! class_exists( 'EDD_Downloads_As_Services' ) ) {
 
 			$is_service = get_post_meta( $item_id, '_edd_das_enabled', true );
 
-			// get payment
-			$payment   = get_post( $edd_receipt_args['id'] );
-			$meta      = isset( $payment ) ? edd_get_payment_meta( $payment->ID ) : '';
-			$cart      = isset( $payment ) ? edd_get_payment_meta_cart_details( $payment->ID, true ) : '';
+			// get cart details
+			$cart = edd_get_payment_meta_cart_details( $edd_receipt_args['id'], true );
 
 			if ( $cart ) {
 				foreach ( $cart as $key => $item ) {

--- a/edd-downloads-as-services.php
+++ b/edd-downloads-as-services.php
@@ -205,7 +205,7 @@ if ( ! class_exists( 'EDD_Downloads_As_Services' ) ) {
 			$is_service = get_post_meta( $item_id, '_edd_das_enabled', true );
 
 			// get cart details
-			$cart = edd_get_payment_meta_cart_details( $edd_receipt_args['id'], true );
+			$cart = ! empty( $edd_receipt_args['id'] ) ? edd_get_payment_meta_cart_details( $edd_receipt_args['id'], true ) : false;
 
 			if ( $cart ) {
 				foreach ( $cart as $key => $item ) {


### PR DESCRIPTION
Closes #10

1. Removes `get_post()` as it's not really used. The full payment object isn't needed; all we need is the payment ID, which we already have.
2. Removes `$meta` call and variable, and it's never used.